### PR TITLE
Changed UIDatePickerMode to UIDatePicker.Mode

### DIFF
--- a/ZZDatePicker/ZZDatePicker.swift
+++ b/ZZDatePicker/ZZDatePicker.swift
@@ -20,7 +20,7 @@ open class ZZDatePicker: UIViewController {
         public var maximumDate:Date?
         public var minimumDate:Date?
         public var backgroundColor:UIColor?
-        public var datePickerMode:UIDatePickerMode = .date
+        public var datePickerMode:UIDatePicker.Mode = .date
         
         public static var `default`:ZZDatePickerMode { get { return ZZDatePickerMode(date: Date(),
                                                                                      maximumDate: Date(),


### PR DESCRIPTION
Changed UIDatePickerMode to UIDatePicker.Mode because of deprecation in Swift >= 4.2